### PR TITLE
fix: No more flickering

### DIFF
--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -113,7 +113,7 @@ export function TagPage() {
           {getTagDisplay()}
         </div>
         <p className="text-[#545454]">
-          {totalCount || 0} {totalCount === 1 ? "app" : "apps"} found
+          {totalCount === undefined ? "Loading..." : `${totalCount || 0} ${totalCount === 1 ? "app" : "apps"} found`}
         </p>
       </div>
 
@@ -129,6 +129,10 @@ export function TagPage() {
           loadMore={loadMore}
           itemsPerPage={20}
         />
+      ) : totalCount === undefined ? (
+        <div className="text-center py-12">
+          <div className="text-[#545454]">Loading apps...</div>
+        </div>
       ) : (
         <div className="text-center py-12">
           <h2 className="text-xl font-medium text-[#292929] mb-2">


### PR DESCRIPTION
How it works now:
Initial load: Shows "Loading..." for the count and "Loading apps..." for the content
After data loads: Shows the actual count and either the stories or "No apps found" message
No more flickering: The UI won't briefly show "0 apps found" before the real count appears