### PR TITLE
fix: resolve sidebar overlap issue on tablet breakpoints

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -729,14 +729,14 @@ export function Layout({ children }: { children?: ReactNode }) {
           </div>
         </header>
         <main className="flex-grow container mx-auto px-4 py-1">
-          <div className="flex flex-col md:flex-row gap-8">
-            <div className={showSidebar ? "md:w-3/4" : "w-full"}>
+          <div className="flex flex-col lg:flex-row gap-8">
+            <div className={showSidebar ? "lg:w-3/4" : "w-full"}>
               {children || (
                 <Outlet context={{ viewMode, selectedTagId, sortPeriod }} />
               )}
             </div>
             {showSidebar && (
-              <aside className="md:w-1/4 space-y-6">
+              <aside className="lg:w-1/4 space-y-6">
                 <WeeklyLeaderboard />
                 <TopCategoriesOfWeek
                   selectedTagId={selectedTagId}
@@ -822,7 +822,7 @@ function DropdownNotificationItem({ alert }: { alert: any }) {
               <span>{getNotificationText()}</span>
             ) : actorUser ? (
               <>
-                <span className="font-medium">{actorUser.name}</span>{" "}
+                <span className="font-medium">{actorUser.name}</span>{" "}Top Categories This Week
                 {getNotificationText()}
               </>
             ) : (


### PR DESCRIPTION
- Change responsive breakpoint from md: (768px) to lg: (1024px)
- Prevents 'Most Vibes This Week' and 'Top Categories This Week' components from overlapping main content between 768px-1023px
- Sidebar now properly stacks below main content on tablet devices
- Maintains side-by-side layout on desktop screens (1024px+)